### PR TITLE
install typings on prestart rather than postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "email": "pleerock.me@gmail.com"
   },
   "scripts": {
+    "prestart": "typings install",
     "start": "tsc && concurrently \"npm run tsc:w\" \"npm run lite\" ",
     "lite": "lite-server -c bs-config.json",
     "tsc": "tsc",
-    "tsc:w": "tsc -w",
-    "postinstall": "typings install"
+    "tsc:w": "tsc -w"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
On my last PR I've set : 

```
"postintall": "typings install" 
```

But since typings isn't a dependency but a devDependency this creates an error on install.
I then moved it to the `prestart` phase.
